### PR TITLE
Make Zotero::Api#get in api.rb understand rel="next" means more entries

### DIFF
--- a/lib/zotero/api.rb
+++ b/lib/zotero/api.rb
@@ -8,9 +8,28 @@ class Zotero::Api
   end
 
   def get(path_fragment)
-    ::JSON.parse(RestClient.get("https://api.zotero.org/users/#{@user_id}/#{path_fragment}", {
-      'Zotero-API-Version' => 3,
-      'Zotero-API-Key' => @key
-    }).body)
+    body = nil 
+    the_next = "https://api.zotero.org/users/#{@user_id}/#{path_fragment}"
+    loop do
+      response = RestClient.get(the_next, {
+        'Zotero-API-Version' => 3,
+        'Zotero-API-Key' => @key
+      })  
+      if body.nil?
+        body = ::JSON.parse(response.body)
+      else
+        body += ::JSON.parse(response.body)
+      end 
+
+      links = response.headers[:link].split(', ')
+      the_next = '' # reset it
+      links.each do |link|
+        if link.end_with?('; rel="next"')
+          the_next = link.match(/<(.+)>/)[1]
+        end 
+      end 
+      break if the_next.empty?
+    end 
+    return body
   end
 end


### PR DESCRIPTION
With the Zotero Api when you get items there is a 25 item limit. If there are more than 25 items a URL is embedded in the response headers within the `:link` header. The proposed code changes makes the code loop while there exists a next URL.

See the docs here: https://www.zotero.org/support/dev/web_api/v3/basics and got to where it says **Link Header**.

I'm pretty sure this doesn't break the normal cases, at least getting an initial collection still works for me, but you may want to add test cases? I haven't done this.